### PR TITLE
Fix: Exclude Next-Gen Dataset files

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ In order to build the pages locally, follow these steps:
 2. Create a new environment and install the dependencies:
     ```bash
     conda create -n careamics-docs python=3.11
+    conda activate careamics-docs
     pip install -r requirements.txt
     ```
 4. Run the following scripts (which are normally run by the CI):

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -188,6 +188,11 @@ plugins:
         - codespell: # or nested configs
             dictionaries: [clear, rare]
 
+  # exclude careamics sources files that are in development
+  - exclude:
+      glob:
+        - "*/careamics/dataset_ng/*"
+
 watch:
   - docs
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ mkdocs-section-index
 mkdocstrings[python]
 mkdocs-jupyter
 mike
+mkdocs-exclude


### PR DESCRIPTION
The docs were not building because the Next-Gen Dataset is in development and it's files don't have complete docstrings.

This PR adds the [`mkdocs-exclude` plugin](https://github.com/apenwarr/mkdocs-exclude) to the requirements and specifies which files to exclude in the mkdocs.yml file.

Note: `dataset_ng` will still appear in the navigation bar because it is created by the `scripts/gen_ref_pages.py` script. However, if any of the pages are clicked it will bring up a 404 erorr.
