### PR TITLE
Fix: Mac MPS mamba install

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -300,7 +300,6 @@ is to look at the [applications](applications/index.md) for full examples and th
 
     3. Install PyTorch following the [official instructions](https://pytorch.org/get-started/locally/)
         while specifying the platform. As an example, our test machine requires:
-        As an example, our test machine requires:
 
         ``` bash
         pip3 install torch torchvision

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -312,7 +312,7 @@ is to look at the [applications](applications/index.md) for full examples and th
 
         If this prints `False`, make sure that you do have an M1, M2 or M3 chip, and that the `conda`/`mamba` macOS-arm64 release was installed correctly.
 
-    4. Install CAREamics napari plugin and napari:
+    5. Install CAREamics napari plugin and napari:
 
         ``` bash
         pip install careamics-napari "napari[all]"

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -298,15 +298,14 @@ is to look at the [applications](applications/index.md) for full examples and th
         mamba activate careamics
         ```
 
-    3. Install PyTorch following the [official 
-        instructions](https://pytorch.org/get-started/locally/)
-
+    3. Install PyTorch following the [official instructions](https://pytorch.org/get-started/locally/)
+        while specifying the platform. As an example, our test machine requires:
         As an example, our test machine requires:
 
         ``` bash
         pip3 install torch torchvision
         ```
-        
+
     4. Verify that GPU is available:
         ```bash
         python -c "import torch; import platform; print((platform.processor() in ('arm', 'arm64') and torch.backends.mps.is_available()))"

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -151,7 +151,7 @@ Here is a list of the extra dependencies:
     2. Create a new environment:
         
         ``` bash
-        mamba create -n careamics python=3.10 --platform osx-64
+        mamba create -n careamics python=3.10 --platform osx-arm64
         mamba activate careamics
         ```
 
@@ -241,7 +241,7 @@ is to look at the [applications](applications/index.md) for full examples and th
         As an example, our test machine requires:
 
         ``` bash
-        mamba install pytorch::pytorch torchvision -c pytorch
+        pip3 install torch torchvision
         ```
 
         :warning: Note that this will probably not install silicon GPU acceleration. If
@@ -294,16 +294,25 @@ is to look at the [applications](applications/index.md) for full examples and th
     2. Create a new environment:
         
         ``` bash
-        mamba create -n careamics python=3.10 --platform osx-64
+        mamba create -n careamics python=3.10 --platform osx-arm64
         mamba activate careamics
         ```
 
-    3. Install PyTorch following the [official instructions](https://pytorch.org/get-started/locally/)
-        while specifying the platform. As an example, our test machine requires:
+    3. Install PyTorch following the [official 
+        instructions](https://pytorch.org/get-started/locally/)
+
+        As an example, our test machine requires:
 
         ``` bash
         pip3 install torch torchvision
         ```
+        
+    4. Verify that GPU is available:
+        ```bash
+        python -c "import torch; import platform; print((platform.processor() in ('arm', 'arm64') and torch.backends.mps.is_available()))"
+        ```
+
+        If this prints `False`, make sure that you do have an M1, M2 or M3 chip, and that the `conda`/`mamba` macOS-arm64 release was installed correctly.
 
     4. Install CAREamics napari plugin and napari:
 


### PR DESCRIPTION
- Fixing a mistake in the mamba mac MPS install.
- Change torch install to pip from mamba
- Add test to verify correct mac MPS install for torch to napari mamba instructions