### PR TITLE
small bug fix: using careamics in Guides

### DIFF
--- a/docs/content/guides/index.md
+++ b/docs/content/guides/index.md
@@ -9,7 +9,7 @@
 
     Use CAREamics in Python.
 
-    [:octicons-arrow-right-24: Configuration](./current/index.md)
+    [:octicons-arrow-right-24: Using CAREamics](./current/index.md)
 
 -   :lucide-graduation-cap:{ .lg .middle } __Tutorials__
 


### PR DESCRIPTION
For Using CAREamics in guides, changed "configuration" link to "Using CAREamics".